### PR TITLE
Add new options for the CSV connector (native)

### DIFF
--- a/src/ploosh/connectors/connector_csv.py
+++ b/src/ploosh/connectors/connector_csv.py
@@ -1,7 +1,7 @@
 # pylint: disable=R0903
 """Connector to read CSV file"""
 
-import ast
+import json
 import pandas as pd
 from connectors.connector import Connector
 
@@ -47,8 +47,8 @@ class ConnectorCSV(Connector):
 
         if configuration["skiprows"] is not None:
             try:
-                skiprows = ast.literal_eval(configuration["skiprows"])
-            except SyntaxError:
+                skiprows = json.loads(configuration["skiprows"])
+            except json.JSONDecodeError:
                 raise ValueError("The variable is neither a list nor an integer.")
 
         if skiprows is not None and not isinstance(skiprows, (list, int)):

--- a/src/ploosh/connectors/connector_csv.py
+++ b/src/ploosh/connectors/connector_csv.py
@@ -15,6 +15,7 @@ class ConnectorCSV(Connector):
         self.configuration_definition = [
             {"name": "path"},  # Path to the CSV file
             {"name": "delimiter", "default": ","},  # Delimiter used in the CSV file
+            {"name": "infer", "type": "boolean", "default": True},  # Infer the column names
             {"name": "names", "type": 'list', "default": None},  # Sequence of column labels to apply
             {"name": "usecols", "type": 'list', "default": None},  # Subset of columns to select
             {"name": "skipfooter", "type": 'integer', "default": 0},  # Number of lines at bottom of file to skip (Unsupported with engine='c')
@@ -31,7 +32,7 @@ class ConnectorCSV(Connector):
         # Extract the path and delimiter from the configuration
         path = configuration["path"]
         delimiter = configuration["delimiter"]
-        header = configuration.get("header", "infer")
+        header = None if configuration["infer"] is False else 'infer'
         names = configuration["names"]
         usecols = configuration["usecols"]
         skiprows = configuration.get("skiprows", None)

--- a/src/ploosh/connectors/connector_csv.py
+++ b/src/ploosh/connectors/connector_csv.py
@@ -17,15 +17,15 @@ class ConnectorCSV(Connector):
             {"name": "path"},  # Path to the CSV file
             {"name": "delimiter", "default": ","},  # Delimiter used in the CSV file
             {"name": "infer", "type": "boolean", "default": True},  # Infer the column names
-            {"name": "names", "type": 'list', "default": None},  # Sequence of column labels to apply
-            {"name": "usecols", "type": 'list', "default": None},  # Subset of columns to select
-            {"name": "skiprows", "type": 'string', "default": None},  # Line numbers to skip (0-indexed) or number of lines to skip (int) at the start of the file
-            {"name": "skipfooter", "type": 'integer', "default": 0},  # Number of lines at bottom of file to skip (Unsupported with engine='c')
-            {"name": "nrows", "type": 'integer', "default": None},  # Number of rows of file to read. Useful for reading pieces of large files.
-            {"name": "lineterminator", "type": 'string', "default": None},  # Character used to denote a line break.
-            {"name": "quotechar", "type": 'string', "default": '"'},  # Character used to denote the start and end of a quoted item.
-            {"name": "encoding", "type": 'string', "default": 'utf-8'},  # Encoding to use for UTF when reading/writing.
-            {"name": "engine", "type": 'string', "default": None},  # Parser engine to use.
+            {"name": "names", "type": "list", "default": None},  # Sequence of column labels to apply
+            {"name": "usecols", "type": "list", "default": None},  # Subset of columns to select
+            {"name": "skiprows", "type": "string", "default": None},  # Line numbers to skip (0-indexed) or number of lines to skip (int) at the start of the file
+            {"name": "skipfooter", "type": "integer", "default": 0},  # Number of lines at bottom of file to skip (Unsupported with engine='c')
+            {"name": "nrows", "type": "integer", "default": None},  # Number of rows of file to read. Useful for reading pieces of large files.
+            {"name": "lineterminator", "type": "string", "default": None},  # Character used to denote a line break.
+            {"name": "quotechar", "type": "string", "default": '"'},  # Character used to denote the start and end of a quoted item.
+            {"name": "encoding", "type": "string", "default": 'utf-8'},  # Encoding to use for UTF when reading/writing.
+            {"name": "engine", "type": "string", "default": None},  # Parser engine to use.
         ]
 
     def get_data(self, configuration: dict, connection: dict):

--- a/src/ploosh/connectors/connector_csv.py
+++ b/src/ploosh/connectors/connector_csv.py
@@ -24,7 +24,7 @@ class ConnectorCSV(Connector):
             {"name": "nrows", "type": "integer", "default": None},  # Number of rows of file to read. Useful for reading pieces of large files.
             {"name": "lineterminator", "type": "string", "default": None},  # Character used to denote a line break.
             {"name": "quotechar", "type": "string", "default": '"'},  # Character used to denote the start and end of a quoted item.
-            {"name": "encoding", "type": "string", "default": 'utf-8'},  # Encoding to use for UTF when reading/writing.
+            {"name": "encoding", "type": "string", "default": "utf-8"},  # Encoding to use for UTF when reading/writing.
             {"name": "engine", "type": "string", "default": None},  # Parser engine to use.
         ]
 
@@ -34,7 +34,7 @@ class ConnectorCSV(Connector):
         # Extract the path and delimiter from the configuration
         path = configuration["path"]
         delimiter = configuration["delimiter"]
-        header = None if configuration["infer"] is False else 'infer'
+        header = None if configuration["infer"] is False else "infer"
         names = configuration["names"]
         usecols = configuration["usecols"]
         skiprows = None

--- a/src/ploosh/connectors/connector_csv.py
+++ b/src/ploosh/connectors/connector_csv.py
@@ -15,15 +15,44 @@ class ConnectorCSV(Connector):
         self.configuration_definition = [
             {"name": "path"},  # Path to the CSV file
             {"name": "delimiter", "default": ","},  # Delimiter used in the CSV file
+            {"name": "names", "type": 'list', "default": None},  # Sequence of column labels to apply
+            {"name": "usecols", "type": 'list', "default": None},  # Subset of columns to select
+            {"name": "skipfooter", "type": 'integer', "default": 0},  # Number of lines at bottom of file to skip (Unsupported with engine='c')
+            {"name": "nrows", "type": 'integer', "default": None},  # Number of rows of file to read. Useful for reading pieces of large files.
+            {"name": "lineterminator", "type": 'string', "default": None},  # Character used to denote a line break.
+            {"name": "quotechar", "type": 'string', "default": '"'},  # Character used to denote the start and end of a quoted item.
+            {"name": "encoding", "type": 'string', "default": 'utf-8'},  # Encoding to use for UTF when reading/writing.
+            {"name": "engine", "type": 'string', "default": None},  # Parser engine to use.
         ]
 
     def get_data(self, configuration: dict, connection: dict):
         """Get data from source"""
-
+ 
         # Extract the path and delimiter from the configuration
         path = configuration["path"]
         delimiter = configuration["delimiter"]
+        header = configuration.get("header", "infer")
+        names = configuration["names"]
+        usecols = configuration["usecols"]
+        skiprows = configuration.get("skiprows", None)
+        skipfooter = configuration["skipfooter"]
+        nrows = configuration["nrows"]
+        lineterminator = configuration["lineterminator"]
+        quotechar = configuration["quotechar"]
+        encoding = configuration["encoding"]
+        engine = configuration["engine"]
 
         # Read the CSV file using pandas with the specified delimiter
-        df = pd.read_csv(path, delimiter=delimiter)
+        df = pd.read_csv(path,
+                         delimiter = delimiter,
+                         header = header,
+                         names = names,
+                         usecols = usecols,
+                         skiprows = skiprows,
+                         skipfooter = skipfooter,
+                         nrows = nrows,
+                         lineterminator = lineterminator,
+                         quotechar = quotechar,
+                         engine = engine,
+                         encoding = encoding)
         return df

--- a/src/ploosh/version.py
+++ b/src/ploosh/version.py
@@ -1,3 +1,3 @@
 """Current version of ploosh"""
 
-PLOOSH_VERSION = "0.2.27"
+PLOOSH_VERSION = "0.2.29"


### PR DESCRIPTION
**Add parameters options to native CSV connector**

```name:``` **header**

```default:``` **True**
```type:``` **boolean**
```behavior:```Infer the column names.
```example:``` **False**

---

```name:``` **names**
```default:``` **None**
```type:``` **list of str**
```behavior:``` Sequence of column labels to apply.
```example:``` **['id', 'Name']**

---

```name:``` **usecols**
```default:``` **None**
```type:``` **list of str or list of int**
```behavior:``` Subset of columns to select, denoted either by column labels or column indices.
```example:``` **['id', 'Name']**,**[0, 1]**

---

```name:``` **skiprows**
```default:``` **None**
```type:``` **int or list of int**
```behavior:``` Line numbers to skip (0-indexed) or number of lines to skip (int) at the start of the file.
```example:``` **2**,**[0, 1]**
**NB:** **We cannot control the type of this attribute with Pyjeb (this attribute can have multiple types).**

---

```name:``` **skipfooter**
```default:``` **0**
```type:``` **int**
```behavior:``` Number of lines at bottom of file to skip.
```example:``` **2**
**NB: This attribute is supported with the Python and PyArrow engines, not with "C".**

---

```name:``` **nrows**
```default:``` **None**
```type:``` **int**
```behavior:``` Number of rows of file to read. Useful for reading pieces of large files.
```example:``` **2**
**NB: This attribute cannot be used together with the skipfooter attribute in the same execution.**

---

```name:``` **lineterminator**
```default:``` **None**
```type:``` **string**
```behavior:``` Character used to denote a line break.
```example:``` **'\n', ";"**

---

```name:``` **quote**
```default:``` **'"'**
```type:``` **string**
```behavior:``` Character used to denote the start and end of a quoted item.
```example:``` **'"'**

---

```name:``` **encoding**
```default:``` **‘utf-8’**
```type:``` **string**
```behavior:``` Encoding to use for UTF when reading/writing (ex. 'utf-8').
```example:``` **‘utf-8’**

---

```name:``` **engine**
```default:``` **None**
```type:``` **string**
```behavior:``` Parser engine to use. The C and pyarrow engines are faster, while the python engine is currently more feature-complete.
```example:``` **"python"**

---