### PR TITLE
Add a new JSON spark connector 

### DIFF
--- a/src/ploosh/connectors/connector_json_spark.py
+++ b/src/ploosh/connectors/connector_json_spark.py
@@ -1,0 +1,30 @@
+# pylint: disable=R0903
+"""Connector to read json file"""
+
+from connectors.connector import Connector
+
+
+class ConnectorJSONSpark(Connector):
+    """Connector to read json file with Spark"""
+
+    def __init__(self):
+        # Initialize the connector with its name and configuration definitions
+        self.name = "JSON_SPARK"
+        self.is_spark = True
+        self.connection_definition = []
+        self.configuration_definition = [
+            {"name": "path", "type": "string"},  # Path to the JSON file
+            {"name": "multiline", "type": "boolean", "default": True},  # Handles multi-line JSON files
+            {"name": "encoding", "type": "string", "default": "UTF-8"},  # Character encoding format used in the JSON file
+            {"name": "lineSep", "type": "string", "default": "\n"}  # Character used to denote a line break
+        ]
+
+    def get_data(self, configuration: dict, connection: dict):
+        """Get data from source"""
+
+        # Read the JSON file using Spark with the specified configuration options
+        df = self.spark.read.option("multiline", configuration["multiline"])    \
+                            .option("encoding", configuration["encoding"])      \
+                            .json(configuration["path"])
+
+        return df

--- a/src/ploosh/connectors/connector_json_spark.py
+++ b/src/ploosh/connectors/connector_json_spark.py
@@ -25,6 +25,7 @@ class ConnectorJSONSpark(Connector):
         # Read the JSON file using Spark with the specified configuration options
         df = self.spark.read.option("multiline", configuration["multiline"])    \
                             .option("encoding", configuration["encoding"])      \
+                            .option("lineSep", configuration["lineSep"])        \
                             .json(configuration["path"])
 
         return df


### PR DESCRIPTION
**Add a new JSON spark connector**

```name:``` **path**
```type:``` **string**
```behavior:```Path to the JSON file.
```example:``` **data/json/source/example.json**

---

```name:``` **multiline**
```default:``` **True**
```type:``` **bool**
```behavior:``` Handles multi-line JSON files
```example:``` **True**

---

```name:``` **encoding**
```default:``` **""UTF-8""**
```type:``` **string**
```behavior:``` Character encoding format used in the JSON file.
```example:``` **"UTF-8"**

---

```name:``` **lineSep**
```default:``` **"\n"**
```type:``` **string**
```behavior:``` Character used to denote a line break.
```example:```**"\n"**


**Update wiki documentation** 