### PR TITLE
Add API mode support and documentation for KQL Spark connector

### DIFF
--- a/docs/connectors/spark/fabric-kql.md
+++ b/docs/connectors/spark/fabric-kql.md
@@ -2,6 +2,10 @@
 
 This connector is used to query Microsoft Fabric KQL databases using Spark and the Kusto Spark connector.
 
+It supports two execution modes:
+- `native` (Spark Kusto connector)
+- `api` (Fabric KQL REST API)
+
 > ⚠️ A Spark connector can only be used with another Spark connector. It is not possible to mix Spark and native connectors in the same test case.
 
 See [Spark mode overview](/docs/spark/overview) for more information.
@@ -10,17 +14,31 @@ See [Spark mode overview](/docs/spark/overview) for more information.
 
 | Name | Mandatory | Default | Description |
 |------|:---------:|:-------:|-------------|
+| connection_mode | no | api | Execution mode: `native` or `api` |
 | kusto_uri | yes | | Kusto cluster URI (e.g. `https://mycluster.kusto.windows.net`) |
-| database_id | yes | | KQL database ID |
+| database_id | yes (native mode) | | KQL database ID used by Spark native connector |
+| database_name | yes (api mode) | | KQL database name used by REST API mode |
 
-### Example
+### Example (native mode)
 
 ``` yaml
 connections:
   kql_connection:
     type: fabric_kql_spark
+    connection_mode: native
     kusto_uri: https://mycluster.kusto.windows.net
     database_id: my_kql_database
+```
+
+### Example (api mode)
+
+``` yaml
+connections:
+  kql_connection:
+    type: fabric_kql_spark
+    connection_mode: api
+    kusto_uri: https://mycluster.kusto.windows.net
+    database_name: my_kql_database
 ```
 
 ## Test case configuration
@@ -51,6 +69,12 @@ Example Fabric KQL:
 ## Authentication
 
 This connector uses the Microsoft Fabric authentication token obtained via `mssparkutils.credentials.getToken("kusto")`. The Spark environment must have access to Microsoft Fabric resources.
+
+## Runtime behavior
+
+- In `api` mode, the connector expects a `PrimaryResult` table in the API response.
+- If the API call fails or no `PrimaryResult` table is returned, the connector raises a clear error.
+- If performance issues are observed with `native` mode, prefer `api` mode.
 
 ## Requirements
 

--- a/docs/spark/fabric-setup.md
+++ b/docs/spark/fabric-setup.md
@@ -64,6 +64,7 @@ Create a `ploosh_connections.yaml` file for your Fabric data sources:
 # For KQL databases
 kql_connection:
   type: fabric_kql_spark
+  connection_mode: native
   kusto_uri: https://mycluster.kusto.windows.net
   database_id: my_kql_database
 

--- a/docs/spark/fabric-shortcuts.md
+++ b/docs/spark/fabric-shortcuts.md
@@ -62,6 +62,7 @@ For workloads that write events to KQL databases, use the `fabric_kql_spark` con
 connections:
   kql_events:
     type: fabric_kql_spark
+    connection_mode: native
     kusto_uri: https://mycluster.kusto.windows.net
     database_id: events_db
 ```

--- a/docs/use-cases/fabric-data-platform.md
+++ b/docs/use-cases/fabric-data-platform.md
@@ -130,6 +130,7 @@ Test product categories:
 ``` yaml
 kql_events:
   type: fabric_kql_spark
+  connection_mode: native
   kusto_uri: https://mycluster.kusto.windows.net
   database_id: events_database
 ```

--- a/src/ploosh/connectors/connector_fabric_kql_spark.py
+++ b/src/ploosh/connectors/connector_fabric_kql_spark.py
@@ -1,5 +1,7 @@
 # pylint: disable=R0903,C0415,C0103
 """Connector to read Fabric KQL data with Spark"""
+import requests
+import pandas as pd
 
 from connectors.connector import Connector
 
@@ -13,10 +15,19 @@ class ConnectorFabricKqlSpark(Connector):
         self.is_spark = True  # Indicates that this connector uses Spark
         self.connection_definition = [
             {
+                "name": "connection_mode",
+                "validset": ["native", "api"],
+                "default": "api"
+            },
+            {
                 "name": "kusto_uri", # Kusto cluster URI
             },
             {
                 "name": "database_id", # KQL Database ID
+            },
+            {
+                "name": "database_name", # KQL Database Name
+                "default": None
             }
             ]
         self.configuration_definition = [
@@ -33,13 +44,57 @@ class ConnectorFabricKqlSpark(Connector):
         # Store the executed query for reference
         self.executed_action = configuration["query"]
 
-        # Read the KQL data using Spark with the specified connection and configuration options
-        df = self.spark.read \
-            .format("com.microsoft.kusto.spark.datasource") \
-            .option("kustoCluster", connection["kusto_uri"]) \
-            .option("kustoDatabase", connection["database_id"]) \
-            .option("kustoQuery", configuration["query"]) \
-            .option("accessToken", access_token) \
-            .load()
+        if connection["connection_mode"] == "native":
+            # Read the KQL data using Spark with the specified connection and configuration options
+            df = self.spark.read \
+                .format("com.microsoft.kusto.spark.datasource") \
+                .option("kustoCluster", connection["kusto_uri"]) \
+                .option("kustoDatabase", connection["database_id"]) \
+                .option("kustoQuery", configuration["query"]) \
+                .option("accessToken", access_token) \
+                .load()
+        else:
+            url = f"{connection['kusto_uri'].rstrip('/')}/v2/rest/query"
+            headers = {
+                "Authorization": f"Bearer {access_token}",
+                "Content-Type": "application/json"
+            }
+            payload = {
+                "db": connection["database_name"],
+                "csl": configuration["query"]
+            }
+
+            response = requests.post(url, json=payload, headers=headers)
+
+            if response.status_code == 200:
+                json_data = response.json()
+                
+                data_table = None
+                for table in json_data:
+                    if table.get("TableKind") == "PrimaryResult":
+                        data_table = table
+                        break
+
+                    elif table.get("FrameType") == "DataTable" and table.get("TableRole") == "PrimaryResult":
+                        data_table = table
+                        break
+
+                if data_table:
+                    columns = [col["ColumnName"] for col in data_table["Columns"]]
+                    rows = data_table["Rows"]
+                    
+                    df = pd.DataFrame(rows, columns=columns)
+                    df = self.spark.createDataFrame(df)
+                else:
+                    raise ValueError(
+                        "Fabric KQL API response does not contain a PrimaryResult table."
+                    )
+            else:
+                raise ValueError(
+                    f"Fabric KQL API request failed with status {response.status_code}: {response.text}"
+                )
+
+        if df is None:
+            raise ValueError("Fabric KQL connector returned no dataframe.")
 
         return df


### PR DESCRIPTION
## Context
The Fabric KQL Spark connector previously relied only on native mode (Kusto Spark datasource).  
This PR introduces an API mode to query KQL through REST, providing a more robust alternative depending on the runtime environment.

## Main changes
- Added a new connection parameter: connection_mode, with values native or api (default: api).
- Added database_name for api mode (while keeping database_id for native mode).
- Implemented api mode in the connector:
  - HTTP POST call to the KQL REST endpoint,
  - extraction of the PrimaryResult table,
  - conversion to a Spark DataFrame through pandas.
- Improved error handling:
  - explicit error when the API call fails,
  - explicit error when no PrimaryResult table is found,
  - explicit error when no final DataFrame is produced.
- Updated documentation and configuration examples to describe both modes clearly.

## Impact and compatibility
- Default behavior changed: default mode is now api.
- Existing configurations without connection_mode may need an update:
  - either set connection_mode: native and keep database_id,
  - or switch to connection_mode: api with database_name.

## Testing
- No new automated tests were added in this PR.

## Checklist
- [x] Feature implemented
- [x] Documentation updated
- [x] Error scenarios covered
- [ ] End-to-end validation on target Fabric environment