### PR TITLE
Update Python compatibility

### DIFF
--- a/.github/workflows/pr_build_matrix.yml
+++ b/.github/workflows/pr_build_matrix.yml
@@ -3,7 +3,7 @@ name: 'Build and test matrix'
 on:
   pull_request:
     branches:
-      - main
+      - *
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/pr_build_matrix.yml
+++ b/.github/workflows/pr_build_matrix.yml
@@ -3,7 +3,7 @@ name: 'Build and test matrix'
 on:
   pull_request:
     branches:
-      - *
+      - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/pr_build_matrix.yml
+++ b/.github/workflows/pr_build_matrix.yml
@@ -1,0 +1,86 @@
+name: 'Build and test matrix'
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: 'Build package'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Build package
+        run: |
+          python -m venv .build
+          . .build/bin/activate
+
+          pip install --upgrade pip
+
+          pip install build==1.5.0
+          pip install twine==6.0.1
+
+          python -m build
+          twine check dist/*
+      - name: Upload package artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ploosh-dist
+          path: dist/*.whl
+
+  test:
+    name: 'Test py${{ matrix.python-version }} [${{ matrix.extra }}]'
+    needs: build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - "3.11"
+          - "3.12"
+          - "3.13"
+        extra:
+          - base
+          - full
+    steps:
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "${{ matrix.python-version }}"
+      - name: Download package artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ploosh-dist
+          path: dist
+      - name: Install package
+        run: |
+          python -m venv .test
+          . .test/bin/activate
+
+          pip install --upgrade pip
+
+          package_path=`ls dist/* | grep .whl`
+
+          if [ "${{ matrix.extra }}" = "base" ]; then
+            pip install "$package_path"
+          else
+            pip install "$package_path[${{ matrix.extra }}]"
+          fi
+      - name: Execute ploosh
+        run: |
+          . .test/bin/activate
+
+          ploosh

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .venv
+.debug
 .pytest_cache
 __pycache__
 /src/build

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
-- Python 3.9 or higher
+- Python 3.11, 3.12 or 3.13
 
 ## Install from PyPi
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "ploosh"
 dynamic = ["version"]
 description = "A framework to automatize your tests for data projects"
 readme = "readme.md"
-requires-python = ">=3.9"
+requires-python = ">=3.11,<3.14"
 license = { text = "Apache License 2.0" }
 keywords = ["testing", "data", "quality", "framework", "yaml"]
 
@@ -16,11 +16,14 @@ dependencies = [
     "rich==13.9.4",
     "PyYAML==6.0.1",
     "Pyjeb==0.2.1",
-    "numpy==1.26.3",
-    "pandas==2.1.4",
+    "requests==2.31.0",
+    "numpy==1.26.3; python_version < '3.13'",
+    "numpy>=2.1.0; python_version >= '3.13'",
+    "pandas==2.1.4; python_version < '3.13'",
+    "pandas>=2.2.3; python_version >= '3.13'",
     "openpyxl==3.1.2",
-    "sqlalchemy==1.4.51",
-    "deltalake==0.23.2",
+    "sqlalchemy==1.4.51; python_version < '3.13'",
+    "sqlalchemy>=1.4.54,<2.0; python_version >= '3.13'",
     "pyarrow==18.0.0",
 ]
 
@@ -42,6 +45,7 @@ spark = [
     "pyspark==3.5.4",
     "delta-spark==3.3.0",
 ]
+delta = ["deltalake==0.23.2"]
 mysql = ["pymysql==1.1.0"]
 postgresql = ["pg8000==1.30.3"]
 sqlserver = ["pyodbc==5.0.1"]
@@ -64,6 +68,8 @@ fabric = ["semantic-link-labs==0.14.3"]
 full = [
     "pyspark==3.5.4",
     "delta-spark==3.3.0",
+    "deltalake==0.23.2",
+    "requests==2.31.0",
     "pymysql==1.1.0",
     "pg8000==1.30.3",
     "pyodbc==5.0.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,8 @@ odbc = ["pyodbc==5.0.1"]
 snowflake = ["snowflake-sqlalchemy==1.5.1"]
 databricks = ["databricks-sql-connector==2.9.3"]
 bigquery = [
-    "sqlalchemy-bigquery==1.9.0",
+    "sqlalchemy-bigquery==1.9.0; python_version < '3.13'",
+    "sqlalchemy-bigquery==1.15.0; python_version >= '3.13'",
     "google-cloud-bigquery-storage==2.24.0",
     "pandas-gbq==0.23.0",
     "pydata-google-auth==1.8.2",
@@ -75,7 +76,8 @@ full = [
     "pyodbc==5.0.1",
     "snowflake-sqlalchemy==1.5.1",
     "databricks-sql-connector==2.9.3",
-    "sqlalchemy-bigquery==1.9.0",
+    "sqlalchemy-bigquery==1.9.0; python_version < '3.13'",
+    "sqlalchemy-bigquery==1.15.0; python_version >= '3.13'",
     "google-cloud-bigquery-storage==2.24.0",
     "pandas-gbq==0.23.0",
     "pydata-google-auth==1.8.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,8 +48,8 @@ spark = [
 delta = ["deltalake==0.23.2"]
 mysql = ["pymysql==1.1.0"]
 postgresql = ["pg8000==1.30.3"]
-sqlserver = ["pyodbc==5.0.1"]
-odbc = ["pyodbc==5.0.1"]
+sqlserver = ["pyodbc==5.2.0"]
+odbc = ["pyodbc==5.2.0"]
 snowflake = ["snowflake-sqlalchemy==1.5.1"]
 databricks = ["databricks-sql-connector==2.9.3"]
 bigquery = [
@@ -73,7 +73,7 @@ full = [
     "requests==2.31.0",
     "pymysql==1.1.0",
     "pg8000==1.30.3",
-    "pyodbc==5.0.1",
+    "pyodbc==5.2.0",
     "snowflake-sqlalchemy==1.5.1",
     "databricks-sql-connector==2.9.3",
     "sqlalchemy-bigquery==1.9.0; python_version < '3.13'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ xmla = [
     "pyadomd==0.1.1",
     "azure-identity>=1.16.0",
 ]
-fabric = ["semantic-link-labs==0.14.3"]
+fabric = ["semantic-link-labs==0.14.3; python_version < '3.13'"]
 
 # Aggregate of every connector (previous `ploosh` full package)
 full = [
@@ -83,7 +83,7 @@ full = [
     "pydata-google-auth==1.8.2",
     "pyadomd==0.1.1",
     "azure-identity>=1.16.0",
-    "semantic-link-labs==0.14.3",
+    "semantic-link-labs==0.14.3; python_version < '3.13'",
 ]
 
 # Development and CI tooling

--- a/src/ploosh/connectors/connector_delta.py
+++ b/src/ploosh/connectors/connector_delta.py
@@ -1,7 +1,6 @@
 # pylint: disable=R0903
 """Connector to read delta file"""
 
-from deltalake import DeltaTable
 from connectors.connector import Connector
 
 
@@ -18,6 +17,8 @@ class ConnectorDELTA(Connector):
 
     def get_data(self, configuration: dict, connection: dict):
         """Get data from source"""
+
+        from deltalake import DeltaTable
 
         # Store the executed action (file path) for reference
         self.executed_action = configuration["path"]


### PR DESCRIPTION
## Summary

Add Python 3.11–3.13 compatibility and a CI build/test matrix to validate the
package across supported versions and extras.

## Changes

### Python version support
- Bump the supported range to `requires-python = ">=3.11,<3.14"` (was `>=3.9`).
- Update the documentation requirements to **Python 3.11, 3.12 or 3.13**.

### Version-conditional dependencies
Core and optional dependencies now use PEP 508 environment markers so that
Python 3.13 installs versions that ship prebuilt wheels and are resolver-compatible:
- `numpy` / `pandas` / `sqlalchemy`: pinned older versions for `< 3.13`, newer
  versions for `>= 3.13`.
- `sqlalchemy-bigquery`: `1.9.0` for `< 3.13`, `1.15.0` for `>= 3.13`.
- `pyodbc`: bumped `5.0.1` → `5.2.0` (ships `cp313` wheels, so no source build
  and no `unixODBC` headers required at install time).
- `semantic-link-labs` (fabric): restricted to `< 3.13` since no release
  supports Python 3.13 yet — the fabric connector is therefore unavailable on
  Python 3.13.

### Packaging cleanup
- Split `deltalake` into a dedicated `delta` extra and add it (plus `requests`)
  explicitly to the `full` aggregate extra.
- Defer the `deltalake` import in `connector_delta.py` to runtime (`get_data`)
  so the package imports cleanly when the optional dependency is not installed.

### CI
- New `pr_build_matrix.yml` workflow (on PRs to `main` + manual dispatch):
  - `build` job: builds the wheel and validates it with `twine check`.
  - `test` job: matrix of Python `3.11 / 3.12 / 3.13` × `base / full` extras,
    installing the built wheel in an isolated venv and running `ploosh`
    (`fail-fast: false`).
- Add `.debug` to `.gitignore`.

## Notes
- The `fabric` extra cannot be installed on Python 3.13 until
  `semantic-link-labs` adds support.