### PR TITLE
Add an new exporter Postgresql

### DIFF
--- a/docs/exporters/postgresql.md
+++ b/docs/exporters/postgresql.md
@@ -1,0 +1,74 @@
+# PostgreSQL exporter
+
+The PostgreSQL exporter writes test case results into a PostgreSQL database table instead of a file. It reuses the [PostgreSQL connector](/docs/connectors/native/postgresql) to connect and run the queries.
+
+The exporter automatically creates the destination table if it does not exist, then inserts one row per test case.
+
+## Connection configuration
+
+The exporter connects through a dedicated `__export__` connection declared in the connections file. The `type` of this connection must match the exporter name (`postgresql`).
+
+The connection accepts the same parameters as the [PostgreSQL connector](/docs/connectors/native/postgresql).
+
+``` yaml
+connections:
+  __export__:
+    type: postgresql
+    hostname: my-server.postgres.database.azure.com
+    database: my_database
+    username: my_user
+    password: $var.postgresql_password
+    port: 5432
+    ssl_context: false
+```
+
+## Destination table
+
+The exporter writes results to a table named `ploosh_results`. The table is created automatically with the following schema:
+
+| Column | Description |
+|--------|-------------|
+| `execution_id` | Unique identifier for the test run |
+| `name` | Test case name |
+| `state` | Result: `passed`, `failed`, `error`, `notExecuted` |
+| `source_start` | Source data loading start time |
+| `source_end` | Source data loading end time |
+| `source_duration` | Source loading duration in seconds |
+| `source_count` | Number of rows in source dataset |
+| `source_executed_action` | Query or path executed for source |
+| `expected_start` | Expected data loading start time |
+| `expected_end` | Expected data loading end time |
+| `expected_duration` | Expected loading duration in seconds |
+| `expected_count` | Number of rows in expected dataset |
+| `expected_executed_action` | Query or path executed for expected |
+| `compare_start` | Comparison start time |
+| `compare_end` | Comparison end time |
+| `compare_duration` | Comparison duration in seconds |
+| `success_rate` | Percentage of matching rows (0.0 to 1.0) |
+
+## Usage
+
+### Command line
+
+``` shell
+ploosh --connections connections.yml --cases test_cases --export POSTGRESQL --p_postgresql_password "your_password"
+```
+
+### Python API
+
+``` python
+from ploosh import execute_cases
+
+execute_cases(
+    cases="test_cases",
+    connections="connections.yml",
+    export="POSTGRESQL",
+    variables={"postgresql_password": "your_password"}
+)
+```
+
+## Requirements
+
+- PostgreSQL optional dependency installed (`pip install ploosh[postgresql]` or `pip install pg8000`)
+- A `__export__` connection of type `postgresql` declared in the connections file
+- Network access to the PostgreSQL database server

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -98,6 +98,7 @@ Exporters save test results to files. All exporters also generate **Excel files 
 | CSV | `test_results.csv` | Flattened results, one row per test |
 | TRX | `test_results.xml` | Visual Studio Test Results format, compatible with Azure DevOps |
 | MySQL | `ploosh_results` table | Results written to a MySQL database table |
+| PostgreSql | `ploosh_results` table | Results written to a PostgreSql database table |
 
 For each failed test, an `.xlsx` file is generated containing only the rows and columns that differ, with `{column}_source` and `{column}_expected` side by side. This makes it easy to identify exactly where source and expected data diverge.
 

--- a/docs/getting-started/what-is-ploosh.md
+++ b/docs/getting-started/what-is-ploosh.md
@@ -53,5 +53,6 @@ Ploosh provides two execution modes to adapt to different environments:
 | CSV | CSV file with flattened results |
 | TRX | Visual Studio Test Results XML format, compatible with Azure DevOps Test Plans |
 | MySQL | Results written to a MySQL database table |
+| PostgreSql | Results written to a PostgreSql database table |
 
 All export formats also generate Excel files (XLSX) with detailed gap analysis for failed test cases.

--- a/docs/home.md
+++ b/docs/home.md
@@ -52,6 +52,7 @@ Ploosh runs natively on Spark for validating large-scale data platforms.
 - [CSV](/docs/exporters/csv) — Flat file format
 - [TRX](/docs/exporters/trx) — Visual Studio Test Results, Azure DevOps compatible
 - [MySQL](/docs/exporters/mysql) — Write results to a MySQL database table
+- [PostgreSql](/docs/exporters/postgresql) — Write results to a PostgreSql database table
 
 ## CI/CD Pipelines
 

--- a/src/ploosh/connectors/connector_postgresql.py
+++ b/src/ploosh/connectors/connector_postgresql.py
@@ -3,7 +3,7 @@
 
 import urllib
 import pandas as pd
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, text
 from connectors.connector import Connector
 
 
@@ -52,9 +52,8 @@ class ConnectorPostgreSQL(Connector):
         ]
         self.configuration_definition = [{"name": "query"}, {"name": "connection"}]
 
-    def get_data(self, configuration: dict, connection: dict):
-        """Get data from source"""
-
+    def __get_sql_connection(self, connection: dict):
+        """Get SQLAlchemy engine connection"""
         # Use the provided connection string if mode is "connection_string"
         connection_string = connection["connection_string"]
         if connection["mode"] == "password":
@@ -80,6 +79,14 @@ class ConnectorPostgreSQL(Connector):
             connection_string, echo=False, connect_args=connect_args
         )
 
+        return sql_connection
+
+    def get_data(self, configuration: dict, connection: dict):
+        """Get data from source"""
+
+        # Get the SQL connection
+        sql_connection = self.__get_sql_connection(connection)
+
         # Store the executed query for reference
         self.executed_action = configuration["query"]
 
@@ -87,3 +94,15 @@ class ConnectorPostgreSQL(Connector):
         df = pd.read_sql(configuration["query"], sql_connection)
 
         return df
+
+    def execute_query(self, query: str, connection: dict, parameters: dict | tuple | None = None):
+        """Execute query on the database"""
+
+        # Get the SQL connection
+        sql_connection = self.__get_sql_connection(connection)
+
+        # Execute the SQL query
+        with sql_connection.begin() as conn:
+            result = conn.execute(text(query), parameters if parameters is not None else {})
+
+        return result

--- a/src/ploosh/exporters/exporter_postgresql.py
+++ b/src/ploosh/exporters/exporter_postgresql.py
@@ -24,7 +24,7 @@ class ExporterPostgreSQL(Exporter):
             success_rate FLOAT 
         );
     """
-    
+
     INSERT_QUERY = """
         INSERT INTO ploosh_results (
             execution_id, name, state,
@@ -45,13 +45,12 @@ class ExporterPostgreSQL(Exporter):
 
     def export(self, cases: dict, execution_id: str):
         """Export test case results to a PostgreSQL database"""
-        
         # Check if connection and connector are available
         if self.connection is None:
-            raise Exception("PostgreSQL export connection not found. Add __export__ section to connections.yml")
+            raise RuntimeError("PostgreSQL export connection not found. Add __export__ section to connections.yml")
         if self.connector is None:
-            raise Exception("PostgreSQL connector not found. Make sure pg8000 is installed.")
-        
+            raise RuntimeError("PostgreSQL connector not found. Make sure pg8000 is installed.")
+
         self.connector.execute_query(self.CREATE_TABLE_QUERY, connection=self.connection)
 
         try:
@@ -79,5 +78,5 @@ class ExporterPostgreSQL(Exporter):
                         "success_rate": case.success_rate,
                     }
                 )
-        except Exception as e:
-            raise Exception(f"Failed to export results to PostgreSQL: {str(e)}")
+        except RuntimeError as e:
+            raise RuntimeError(f"Failed to export results to PostgreSQL: {str(e)}") from e

--- a/src/ploosh/exporters/exporter_postgresql.py
+++ b/src/ploosh/exporters/exporter_postgresql.py
@@ -1,0 +1,83 @@
+from exporters.exporter import Exporter
+
+class ExporterPostgreSQL(Exporter):
+    """Export test case result to PostgreSQL database"""
+
+    CREATE_TABLE_QUERY = """
+        CREATE TABLE IF NOT EXISTS ploosh_results (
+            execution_id VARCHAR(255),
+            name VARCHAR(255),
+            state VARCHAR(50),
+            source_start TIMESTAMP,
+            source_end TIMESTAMP,
+            source_duration FLOAT,
+            source_count BIGINT,
+            source_executed_action VARCHAR(255),
+            expected_start TIMESTAMP,
+            expected_end TIMESTAMP,
+            expected_duration FLOAT,
+            expected_count BIGINT,
+            expected_executed_action VARCHAR(255),
+            compare_start TIMESTAMP,
+            compare_end TIMESTAMP,
+            compare_duration FLOAT,
+            success_rate FLOAT 
+        );
+    """
+    
+    INSERT_QUERY = """
+        INSERT INTO ploosh_results (
+            execution_id, name, state,
+            source_start, source_end, source_duration, source_count, source_executed_action,
+            expected_start, expected_end, expected_duration, expected_count, expected_executed_action,
+            compare_start, compare_end, compare_duration, success_rate
+        ) VALUES (
+            :execution_id, :name, :state,
+            :source_start, :source_end, :source_duration, :source_count, :source_executed_action,
+            :expected_start, :expected_end, :expected_duration, :expected_count, :expected_executed_action,
+            :compare_start, :compare_end, :compare_duration, :success_rate
+        );
+    """
+
+    def __init__(self):
+        # Set the name of the exporter
+        self.name = "POSTGRESQL"
+
+    def export(self, cases: dict, execution_id: str):
+        """Export test case results to a PostgreSQL database"""
+        
+        # Check if connection and connector are available
+        if self.connection is None:
+            raise Exception("PostgreSQL export connection not found. Add __export__ section to connections.yml")
+        if self.connector is None:
+            raise Exception("PostgreSQL connector not found. Make sure pg8000 is installed.")
+        
+        self.connector.execute_query(self.CREATE_TABLE_QUERY, connection=self.connection)
+
+        try:
+            for case_name, case in cases.items():
+                self.connector.execute_query(
+                    self.INSERT_QUERY,
+                    connection=self.connection,
+                    parameters={
+                        "execution_id": execution_id,
+                        "name": case_name,
+                        "state": case.state,
+                        "source_start": case.source.duration.start,
+                        "source_end": case.source.duration.end,
+                        "source_duration": case.source.duration.duration,
+                        "source_count": case.source.count,
+                        "source_executed_action": case.source.executed_action,
+                        "expected_start": case.expected.duration.start,
+                        "expected_end": case.expected.duration.end,
+                        "expected_duration": case.expected.duration.duration,
+                        "expected_count": case.expected.count,
+                        "expected_executed_action": case.expected.executed_action,
+                        "compare_start": case.compare_duration.start,
+                        "compare_end": case.compare_duration.end,
+                        "compare_duration": case.compare_duration.duration,
+                        "success_rate": case.success_rate,
+                    }
+                )
+        except Exception as e:
+            raise Exception(f"Failed to export results to PostgreSQL: {str(e)}")

--- a/tests/exporters/test_postgresql.py
+++ b/tests/exporters/test_postgresql.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from ploosh.exporters.exporter_postgresql import ExporterPostgreSQL
 
 
+
 class MockDuration:
     def __init__(self, start, end, duration):
         self.start = start

--- a/tests/exporters/test_postgresql.py
+++ b/tests/exporters/test_postgresql.py
@@ -1,0 +1,206 @@
+import pytest
+from datetime import datetime
+from ploosh.exporters.exporter_postgresql import ExporterPostgreSQL
+
+
+class MockDuration:
+    def __init__(self, start, end, duration):
+        self.start = start
+        self.end = end
+        self.duration = duration
+
+
+class MockSource:
+    def __init__(self, executed_action=None, count=10):
+        self.duration = MockDuration(datetime(2024, 10, 7, 11, 55, 0), datetime(2024, 10, 7, 11, 55, 5), 5)
+        self.count = count
+        self.executed_action = executed_action
+
+
+class MockCase:
+    def __init__(self, state, source_executed_action=None, expected_executed_action=None, success_rate=0.95):
+        self.state = state
+        self.source = MockSource(source_executed_action)
+        self.expected = MockSource(expected_executed_action)
+        self.compare_duration = MockDuration(datetime(2024, 10, 7, 11, 55, 13), datetime(2024, 10, 7, 11, 55, 15), 2)
+        self.success_rate = success_rate
+
+
+class MockConnector:
+    """Capture every execute_query call without touching a real database."""
+
+    def __init__(self):
+        self.calls = []  # list of dicts: {"query", "connection", "parameters"}
+
+    def execute_query(self, query, connection, parameters=None):
+        self.calls.append({
+            "query": query,
+            "connection": connection,
+            "parameters": parameters,
+        })
+        return None
+
+
+@pytest.fixture
+def connection():
+    return {"type": "postgresql", "hostname": "localhost", "database": "test_db", "port": 5432}
+
+
+@pytest.fixture
+def exporter(connection):
+    exporter = ExporterPostgreSQL()
+    exporter.connector = MockConnector()
+    exporter.connection = connection
+    return exporter
+
+
+def test_create_table_called_once(exporter):
+    cases = {
+        "test_case_1": MockCase("passed", "SELECT * FROM table1", "SELECT * FROM table2"),
+    }
+
+    exporter.export(cases, "test_execution_123")
+
+    # First call must be the CREATE TABLE statement, without parameters
+    first_call = exporter.connector.calls[0]
+    assert first_call["query"] == ExporterPostgreSQL.CREATE_TABLE_QUERY
+    assert first_call["parameters"] is None
+
+
+def test_insert_per_case(exporter):
+    cases = {
+        "test_case_1": MockCase("passed"),
+        "test_case_2": MockCase("failed"),
+        "test_case_3": MockCase("error"),
+    }
+
+    exporter.export(cases, "test_execution_123")
+
+    # 1 CREATE TABLE + 1 INSERT per case
+    assert len(exporter.connector.calls) == 1 + len(cases)
+
+    insert_calls = exporter.connector.calls[1:]
+    assert all(call["query"] == ExporterPostgreSQL.INSERT_QUERY for call in insert_calls)
+
+
+def test_insert_parameters_mapping(exporter):
+    cases = {
+        "test_case_1": MockCase("passed", "SELECT * FROM table1", "SELECT * FROM table2"),
+    }
+
+    exporter.export(cases, "test_execution_123")
+
+    params = exporter.connector.calls[1]["parameters"]
+
+    assert params["execution_id"] == "test_execution_123"
+    assert params["name"] == "test_case_1"
+    assert params["state"] == "passed"
+    assert params["source_duration"] == 5
+    assert params["source_count"] == 10
+    assert params["source_executed_action"] == "SELECT * FROM table1"
+    assert params["expected_duration"] == 5
+    assert params["expected_count"] == 10
+    assert params["expected_executed_action"] == "SELECT * FROM table2"
+    assert params["compare_duration"] == 2
+    assert params["success_rate"] == 0.95
+
+
+def test_execution_id_propagated(exporter):
+    cases = {
+        "test_case_1": MockCase("passed"),
+        "test_case_2": MockCase("failed"),
+    }
+
+    exporter.export(cases, "shared_execution_id")
+
+    insert_calls = exporter.connector.calls[1:]
+    assert all(call["parameters"]["execution_id"] == "shared_execution_id" for call in insert_calls)
+
+
+def test_datetime_passed_raw(exporter):
+    cases = {
+        "test_case_1": MockCase("passed"),
+    }
+
+    exporter.export(cases, "test_execution_123")
+
+    params = exporter.connector.calls[1]["parameters"]
+
+    # PostgreSQL exporter forwards raw datetime objects (no ISO string conversion)
+    assert isinstance(params["source_start"], datetime)
+    assert isinstance(params["source_end"], datetime)
+    assert isinstance(params["expected_start"], datetime)
+    assert isinstance(params["expected_end"], datetime)
+    assert isinstance(params["compare_start"], datetime)
+    assert isinstance(params["compare_end"], datetime)
+    assert params["source_start"] == datetime(2024, 10, 7, 11, 55, 0)
+    assert params["compare_end"] == datetime(2024, 10, 7, 11, 55, 15)
+
+
+def test_connection_forwarded(exporter, connection):
+    cases = {
+        "test_case_1": MockCase("passed"),
+    }
+
+    exporter.export(cases, "test_execution_123")
+
+    assert all(call["connection"] == connection for call in exporter.connector.calls)
+
+
+def test_multiple_states(exporter):
+    cases = {
+        "passed_case": MockCase("passed"),
+        "failed_case": MockCase("failed"),
+        "error_case": MockCase("error"),
+    }
+
+    exporter.export(cases, "test_execution_123")
+
+    states = [call["parameters"]["state"] for call in exporter.connector.calls[1:]]
+    names = [call["parameters"]["name"] for call in exporter.connector.calls[1:]]
+
+    assert states == ["passed", "failed", "error"]
+    assert names == ["passed_case", "failed_case", "error_case"]
+
+
+def test_empty_cases(exporter):
+    exporter.export({}, "test_execution_123")
+
+    # Only the CREATE TABLE statement should be executed, no INSERT
+    assert len(exporter.connector.calls) == 1
+    assert exporter.connector.calls[0]["query"] == ExporterPostgreSQL.CREATE_TABLE_QUERY
+
+
+def test_query_uses_named_params(exporter):
+    cases = {
+        "test_case_1": MockCase("passed"),
+    }
+
+    exporter.export(cases, "test_execution_123")
+
+    insert_query = exporter.connector.calls[1]["query"]
+
+    for placeholder in [":execution_id", ":name", ":state", ":source_start", ":success_rate"]:
+        assert placeholder in insert_query
+
+
+def test_connection_missing_raises_error():
+    exporter = ExporterPostgreSQL()
+    exporter.connector = MockConnector()
+    exporter.connection = None
+
+    cases = {"test_case_1": MockCase("passed")}
+
+    with pytest.raises(Exception, match="PostgreSQL export connection not found"):
+        exporter.export(cases, "test_execution_123")
+
+
+def test_connector_missing_raises_error():
+    exporter = ExporterPostgreSQL()
+    exporter.connector = None
+    exporter.connection = {"type": "postgresql", "hostname": "localhost"}
+
+    cases = {"test_case_1": MockCase("passed")}
+
+    with pytest.raises(Exception, match="PostgreSQL connector not found"):
+        exporter.export(cases, "test_execution_123")


### PR DESCRIPTION
### Description

Adds a new POSTGRESQL exporter that writes test case results directly into a database, and refactors the export pipeline so exporters rely on the existing connections and connectors.

### Type of change

- [x] feat — new feature
- [x] docs — documentation
- [x] refactor — code change
- [x] test — adding tests

### Scope

`exporter`, `connector`, `docs
`
### Changes

- **PostgreSql exporter**: new exporter_postgresql.py that creates the `ploosh_results` table if needed and inserts one row per case using named parameterized queries.
- **Postgresql connector**: added `execute_query()` and extracted the SQL connection into `__get_sql_connection()` (reused by `get_data`).
- **Docs**: new mysql.md page, plus PostgreSql added to the home, concepts and what-is-ploosh pages.

### How has this been tested?

```bash
pytest tests/exporters/test_postgresql.py
```

- [x] `pytest` passes locally
- [x] Tests added for the new logic (test_postgresql.py)

### Documentation

- [x] Docs updated (new POSTGRESQL page)

### Checklist

- [x] Commits follow conventional commits
- [x] Focused changes
- [x] Comments/docs in English
- [x] Existing APIs and naming preserve