### PR TITLE
v0.6.0

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -45,3 +45,4 @@ pytest
 - Include tests for new logic or bug fixes when feasible.
 - Avoid unrelated refactors in feature or fix PRs.
 - Ensure code and docs remain consistent before finalizing.
+- Follow the PR template in `.github/pull_request_template.md` when describing changes.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,56 @@
+<!--
+Thanks for contributing to Ploosh!
+Please fill in the sections below. Remove any section that does not apply.
+-->
+
+## Description
+
+<!-- Summarize what this PR does and why. Link any related issue with "Closes #123". -->
+
+## Type of change
+
+<!-- Use conventional commit types. Check all that apply. -->
+
+- [ ] feat — new feature
+- [ ] fix — bug fix
+- [ ] docs — documentation only
+- [ ] style — formatting, no code change
+- [ ] refactor — code change that neither fixes a bug nor adds a feature
+- [ ] perf — performance improvement
+- [ ] test — adding or updating tests
+- [ ] chore — build, tooling, or maintenance
+
+## Scope
+
+<!-- Impacted area(s): connector, compare-engine, load-engine, exporter, docs, ... -->
+
+## Changes
+
+<!-- Bullet list of the main changes. -->
+
+-
+
+## How has this been tested?
+
+<!-- Describe the tests you ran and how to reproduce them. -->
+
+```bash
+pytest
+```
+
+- [ ] `pytest` passes locally
+- [ ] Added or updated tests for new logic / bug fixes
+- [ ] Connector changes covered by `tests/connectors`
+- [ ] Compare/load changes covered by `tests/compare_engine` / `tests/load_engine`
+
+## Documentation
+
+- [ ] Updated relevant docs under `docs/` (behavior or configuration changed)
+- [ ] No documentation change needed
+
+## Checklist
+
+- [ ] Commits follow conventional commits (`<type>(<scope>): <description>`)
+- [ ] Changes are focused and minimal (no unrelated refactors)
+- [ ] Comments and documentation are written in English
+- [ ] Existing APIs and naming preserved (unless an intentional breaking change)

--- a/docs/exporters/mysql.md
+++ b/docs/exporters/mysql.md
@@ -1,0 +1,59 @@
+# MySQL exporter
+
+The MySQL exporter writes test case results into a MySQL database table instead of a file. It reuses the [MySQL connector](/docs/connectors/native/mysql) to connect and run the queries.
+
+The exporter automatically creates the destination table if it does not exist, then inserts one row per test case.
+
+## Connection configuration
+
+The exporter connects through a dedicated `__export__` connection declared in the connections file. The `type` of this connection must match the exporter name (`mysql`).
+
+The connection accepts the same parameters as the [MySQL connector](/docs/connectors/native/mysql).
+
+``` yaml
+connections:
+  __export__:
+    type: mysql
+    hostname: my-server.database.windows.net
+    database: my_database
+    username: my_user
+    password: $var.mysql_password
+    port: 3306
+```
+
+## Destination table
+
+The exporter writes results to a table named `ploosh_results` by default. You can change this name by setting the `table` parameter in the connection configuration.
+
+| Column | Description |
+|--------|-------------|
+| `execution_id` | Unique identifier for the test run |
+| `name` | Test case name |
+| `state` | Result: `passed`, `failed`, `error`, `notExecuted` |
+| `source_start` | Source data loading start time |
+| `source_end` | Source data loading end time |
+| `source_duration` | Source loading duration in seconds |
+| `source_count` | Number of rows in source dataset |
+| `source_executed_action` | Query or path executed for source |
+| `expected_start` | Expected data loading start time |
+| `expected_end` | Expected data loading end time |
+| `expected_duration` | Expected loading duration in seconds |
+| `expected_count` | Number of rows in expected dataset |
+| `expected_executed_action` | Query or path executed for expected |
+| `compare_start` | Comparison start time |
+| `compare_end` | Comparison end time |
+| `compare_duration` | Comparison duration in seconds |
+| `success_rate` | Percentage of matching rows (0.0 to 1.0) |
+
+## Usage
+
+### Command line
+
+``` shell
+ploosh --connections connections.yml --cases test_cases --export MYSQL
+```
+
+## Requirements
+
+- MySQL optional dependency installed (`pip install ploosh[mysql]`)
+- A `__export__` connection of type `mysql` declared in the connections file

--- a/docs/exporters/postgresql.md
+++ b/docs/exporters/postgresql.md
@@ -1,0 +1,74 @@
+# PostgreSQL exporter
+
+The PostgreSQL exporter writes test case results into a PostgreSQL database table instead of a file. It reuses the [PostgreSQL connector](/docs/connectors/native/postgresql) to connect and run the queries.
+
+The exporter automatically creates the destination table if it does not exist, then inserts one row per test case.
+
+## Connection configuration
+
+The exporter connects through a dedicated `__export__` connection declared in the connections file. The `type` of this connection must match the exporter name (`postgresql`).
+
+The connection accepts the same parameters as the [PostgreSQL connector](/docs/connectors/native/postgresql).
+
+``` yaml
+connections:
+  __export__:
+    type: postgresql
+    hostname: my-server.postgres.database.azure.com
+    database: my_database
+    username: my_user
+    password: $var.postgresql_password
+    port: 5432
+    ssl_context: false
+```
+
+## Destination table
+
+The exporter writes results to a table named `ploosh_results`. The table is created automatically with the following schema:
+
+| Column | Description |
+|--------|-------------|
+| `execution_id` | Unique identifier for the test run |
+| `name` | Test case name |
+| `state` | Result: `passed`, `failed`, `error`, `notExecuted` |
+| `source_start` | Source data loading start time |
+| `source_end` | Source data loading end time |
+| `source_duration` | Source loading duration in seconds |
+| `source_count` | Number of rows in source dataset |
+| `source_executed_action` | Query or path executed for source |
+| `expected_start` | Expected data loading start time |
+| `expected_end` | Expected data loading end time |
+| `expected_duration` | Expected loading duration in seconds |
+| `expected_count` | Number of rows in expected dataset |
+| `expected_executed_action` | Query or path executed for expected |
+| `compare_start` | Comparison start time |
+| `compare_end` | Comparison end time |
+| `compare_duration` | Comparison duration in seconds |
+| `success_rate` | Percentage of matching rows (0.0 to 1.0) |
+
+## Usage
+
+### Command line
+
+``` shell
+ploosh --connections connections.yml --cases test_cases --export POSTGRESQL --p_postgresql_password "your_password"
+```
+
+### Python API
+
+``` python
+from ploosh import execute_cases
+
+execute_cases(
+    cases="test_cases",
+    connections="connections.yml",
+    export="POSTGRESQL",
+    variables={"postgresql_password": "your_password"}
+)
+```
+
+## Requirements
+
+- PostgreSQL optional dependency installed (`pip install ploosh[postgresql]` or `pip install pg8000`)
+- A `__export__` connection of type `postgresql` declared in the connections file
+- Network access to the PostgreSQL database server

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -98,6 +98,7 @@ Exporters save test results to files. All exporters also generate **Excel files 
 | CSV | `test_results.csv` | Flattened results, one row per test |
 | TRX | `test_results.xml` | Visual Studio Test Results format, compatible with Azure DevOps |
 | MySQL | `ploosh_results` table | Results written to a MySQL database table |
+| PostgreSql | `ploosh_results` table | Results written to a PostgreSql database table |
 
 For each failed test, an `.xlsx` file is generated containing only the rows and columns that differ, with `{column}_source` and `{column}_expected` side by side. This makes it easy to identify exactly where source and expected data diverge.
 

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -97,6 +97,7 @@ Exporters save test results to files. All exporters also generate **Excel files 
 | JSON | `test_results.json` | Structured results with nested objects |
 | CSV | `test_results.csv` | Flattened results, one row per test |
 | TRX | `test_results.xml` | Visual Studio Test Results format, compatible with Azure DevOps |
+| MySQL | `ploosh_results` table | Results written to a MySQL database table |
 
 For each failed test, an `.xlsx` file is generated containing only the rows and columns that differ, with `{column}_source` and `{column}_expected` side by side. This makes it easy to identify exactly where source and expected data diverge.
 

--- a/docs/getting-started/what-is-ploosh.md
+++ b/docs/getting-started/what-is-ploosh.md
@@ -53,5 +53,6 @@ Ploosh provides two execution modes to adapt to different environments:
 | CSV | CSV file with flattened results |
 | TRX | Visual Studio Test Results XML format, compatible with Azure DevOps Test Plans |
 | MySQL | Results written to a MySQL database table |
+| PostgreSql | Results written to a PostgreSql database table |
 
 All export formats also generate Excel files (XLSX) with detailed gap analysis for failed test cases.

--- a/docs/getting-started/what-is-ploosh.md
+++ b/docs/getting-started/what-is-ploosh.md
@@ -52,5 +52,6 @@ Ploosh provides two execution modes to adapt to different environments:
 | JSON | JSON file with detailed results |
 | CSV | CSV file with flattened results |
 | TRX | Visual Studio Test Results XML format, compatible with Azure DevOps Test Plans |
+| MySQL | Results written to a MySQL database table |
 
 All export formats also generate Excel files (XLSX) with detailed gap analysis for failed test cases.

--- a/docs/home.md
+++ b/docs/home.md
@@ -52,6 +52,7 @@ Ploosh runs natively on Spark for validating large-scale data platforms.
 - [CSV](/docs/exporters/csv) — Flat file format
 - [TRX](/docs/exporters/trx) — Visual Studio Test Results, Azure DevOps compatible
 - [MySQL](/docs/exporters/mysql) — Write results to a MySQL database table
+- [PostgreSql](/docs/exporters/postgresql) — Write results to a PostgreSql database table
 
 ## CI/CD Pipelines
 

--- a/docs/home.md
+++ b/docs/home.md
@@ -51,6 +51,7 @@ Ploosh runs natively on Spark for validating large-scale data platforms.
 - [JSON](/docs/exporters/json) — Default format, structured results
 - [CSV](/docs/exporters/csv) — Flat file format
 - [TRX](/docs/exporters/trx) — Visual Studio Test Results, Azure DevOps compatible
+- [MySQL](/docs/exporters/mysql) — Write results to a MySQL database table
 
 ## CI/CD Pipelines
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,7 @@ version = { attr = "ploosh.version.PLOOSH_VERSION" }
 name = "cz_conventional_commits"
 version_scheme = "pep440"
 version_provider = "commitizen"
-version = "0.5.6"
+version = "0.6.0"
 check_consistency = true
 version_files = [
     "src/ploosh/version.py:PLOOSH_VERSION",

--- a/src/ploosh/__init__.py
+++ b/src/ploosh/__init__.py
@@ -16,7 +16,8 @@ def execute_cases(
     filter=None,
     path_output=None,
     variables=None,
-    workers = 1
+    workers = 1,
+    export="json"
 ):
     """Execute test cases with the given parameters"""
     args = ["ploosh"]
@@ -56,6 +57,11 @@ def execute_cases(
         for key, value in variables.items():
             args.append(f"--p_{key}")
             args.append(value)
+
+    # Add exporter parameter to arguments if provided
+    if export is not None:
+        args.append("--export")
+        args.append(export)
 
     # Execute the test cases with the constructed arguments
     execute(args, spark_session)

--- a/src/ploosh/configuration.py
+++ b/src/ploosh/configuration.py
@@ -43,14 +43,13 @@ class Configuration:
         {"name": "expected.connection", "default": None},
     ]
 
-    def __init__(self, parameters: Parameters, connectors: dict, exporters: dict):
+    def __init__(self, parameters: Parameters, connectors: dict):
         """Initialize Configuration with parameters, connectors, and exporters"""
         self.parameters = parameters
         self.connectors = connectors
 
         # Initialize connections and set the exporter
         self.init_connections()
-        self.set_exporter(exporters)
 
     def get_module_type(self, obj: dict):
         """Get type of module from user configuration"""

--- a/src/ploosh/connectors/connector.py
+++ b/src/ploosh/connectors/connector.py
@@ -15,6 +15,10 @@ class Connector:
         """Get data from connector"""
         return None  # This method should be overridden by subclasses to fetch data
 
+    def execute_query(self, query: str, connection: dict, parameters: dict | tuple | None = None):
+        """Execute the action defined in the configuration (e.g., run a query, execute a command, etc.)"""
+        return None
+
     def get_executed_action(self):
         """Get executed query, command, file path, etc."""
         return self.executed_action  # This method should be overridden by subclasses to return executed actions

--- a/src/ploosh/connectors/connector_fabric_kql_spark.py
+++ b/src/ploosh/connectors/connector_fabric_kql_spark.py
@@ -37,6 +37,7 @@ class ConnectorFabricKqlSpark(Connector):
     def get_data(self, configuration: dict, connection: dict):
         """Get data from source"""
 
+        from pyspark.sql.types import StructType
         from notebookutils import mssparkutils
 
         access_token = mssparkutils.credentials.getToken("kusto")
@@ -83,12 +84,17 @@ class ConnectorFabricKqlSpark(Connector):
                     columns = [col["ColumnName"] for col in data_table["Columns"]]
                     rows = data_table["Rows"]
 
-                    df = pd.DataFrame(rows, columns=columns)
-                    df = self.spark.createDataFrame(df)
+                    if not rows or len(rows) == 0 or not columns or len(columns) == 0:
+                        empty_rdd = self.spark.sparkContext.emptyRDD()
+                        columns = StructType([])
+                        df = self.spark.createDataFrame(data = empty_rdd, schema = columns)
+                    else:
+                        df = pd.DataFrame(rows, columns=columns)
+                        df = self.spark.createDataFrame(df)
                 else:
-                    raise ValueError(
-                        "Fabric KQL API response does not contain a PrimaryResult table."
-                    )
+                    empty_rdd = self.spark.sparkContext.emptyRDD()
+                    columns = StructType([])
+                    df = self.spark.createDataFrame(data = empty_rdd, schema = columns)
             else:
                 raise ValueError(
                     f"Fabric KQL API request failed with status {response.status_code}: {response.text}"

--- a/src/ploosh/connectors/connector_mysql.py
+++ b/src/ploosh/connectors/connector_mysql.py
@@ -3,7 +3,7 @@
 
 import urllib
 import pandas as pd
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, text
 from connectors.connector import Connector
 
 
@@ -52,9 +52,7 @@ class ConnectorMYSQL(Connector):
         ]
         self.configuration_definition = [{"name": "query"}, {"name": "connection"}]
 
-    def get_data(self, configuration: dict, connection: dict):
-        """Get data from source"""
-
+    def __get_sql_connection(self, connection: dict):
         # Use the provided connection string if mode is "connection_string"
         connection_string = connection["connection_string"]
         if connection["mode"] == "password":
@@ -81,6 +79,14 @@ class ConnectorMYSQL(Connector):
             connection_string, echo = False, connect_args = connect_args
         )
 
+        return sql_connection
+
+    def get_data(self, configuration: dict, connection: dict):
+        """Get data from source"""
+
+        # Get the SQL connection
+        sql_connection = self.__get_sql_connection(connection)
+
         # Store the executed query for reference
         self.executed_action = configuration["query"]
 
@@ -88,3 +94,15 @@ class ConnectorMYSQL(Connector):
         df = pd.read_sql(configuration["query"], sql_connection)
 
         return df
+
+    def execute_query(self, query: str, connection: dict, parameters: dict | tuple | None = None):
+        """Execute query on the database"""
+
+        # Get the SQL connection
+        sql_connection = self.__get_sql_connection(connection)
+
+        # Execute the SQL query
+        with sql_connection.begin() as conn:
+            result = conn.execute(text(query), parameters if parameters is not None else {})
+
+        return result

--- a/src/ploosh/connectors/connector_postgresql.py
+++ b/src/ploosh/connectors/connector_postgresql.py
@@ -3,7 +3,7 @@
 
 import urllib
 import pandas as pd
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, text
 from connectors.connector import Connector
 
 
@@ -52,9 +52,8 @@ class ConnectorPostgreSQL(Connector):
         ]
         self.configuration_definition = [{"name": "query"}, {"name": "connection"}]
 
-    def get_data(self, configuration: dict, connection: dict):
-        """Get data from source"""
-
+    def __get_sql_connection(self, connection: dict):
+        """Get SQLAlchemy engine connection"""
         # Use the provided connection string if mode is "connection_string"
         connection_string = connection["connection_string"]
         if connection["mode"] == "password":
@@ -80,6 +79,14 @@ class ConnectorPostgreSQL(Connector):
             connection_string, echo=False, connect_args=connect_args
         )
 
+        return sql_connection
+
+    def get_data(self, configuration: dict, connection: dict):
+        """Get data from source"""
+
+        # Get the SQL connection
+        sql_connection = self.__get_sql_connection(connection)
+
         # Store the executed query for reference
         self.executed_action = configuration["query"]
 
@@ -87,3 +94,15 @@ class ConnectorPostgreSQL(Connector):
         df = pd.read_sql(configuration["query"], sql_connection)
 
         return df
+
+    def execute_query(self, query: str, connection: dict, parameters: dict | tuple | None = None):
+        """Execute query on the database"""
+
+        # Get the SQL connection
+        sql_connection = self.__get_sql_connection(connection)
+
+        # Execute the SQL query
+        with sql_connection.begin() as conn:
+            result = conn.execute(text(query), parameters if parameters is not None else {})
+
+        return result

--- a/src/ploosh/engines/compare_engine_spark.py
+++ b/src/ploosh/engines/compare_engine_spark.py
@@ -174,13 +174,12 @@ class CompareEngineSpark(CompareEngine):
                 self.error_message = "Some rows are not equal between source dataset and expected dataset"
                 self.error_type = "data"
 
-
-                nouvelles_colonnes = []
+                new_columns = []
                 for column in df_differences.columns:
-                    base, suffixe = column.rsplit('_', maxsplit=1)
-                    nouvelles_colonnes.append((base, suffixe))
+                    base, suffix = column.rsplit('_', maxsplit=1)
+                    new_columns.append((base, suffix))
 
-                df_differences.columns = pd.MultiIndex.from_tuples(nouvelles_colonnes)
+                df_differences.columns = pd.MultiIndex.from_tuples(new_columns)
 
                 self.df_compare_gap = df_differences.reindex(sorted(df_differences.columns), axis=1)
 

--- a/src/ploosh/engines/compare_engine_spark.py
+++ b/src/ploosh/engines/compare_engine_spark.py
@@ -1,5 +1,6 @@
 """Comparison engine for spark connectors"""
 
+import pandas as pd
 from pyspark.sql import DataFrame, Window
 from pyspark.sql.functions import col, lower, trim, abs, when, lit, row_number
 from pyspark.sql.types import NumericType
@@ -173,7 +174,15 @@ class CompareEngineSpark(CompareEngine):
                 self.error_message = "Some rows are not equal between source dataset and expected dataset"
                 self.error_type = "data"
 
-            self.df_compare_gap = df_differences.reindex(sorted(df_differences.columns), axis=1)
+
+                nouvelles_colonnes = []
+                for column in df_differences.columns:
+                    base, suffixe = column.rsplit('_', maxsplit=1)
+                    nouvelles_colonnes.append((base, suffixe))
+
+                df_differences.columns = pd.MultiIndex.from_tuples(nouvelles_colonnes)
+
+                self.df_compare_gap = df_differences.reindex(sorted(df_differences.columns), axis=1)
 
             return False
 

--- a/src/ploosh/execute.py
+++ b/src/ploosh/execute.py
@@ -108,13 +108,15 @@ def execute(args=None, spark_session=None):
         # Load connectors and exporters
         Log.print_message("Load connectors")
         connectors = get_connectors(spark_session)
-        Log.print_message("Load exporters")
-        exporters = get_exporters()
 
         # Load configuration and test cases
         Log.print_message("Load configuration")
-        configuration = Configuration(parameters, connectors, exporters)
+        configuration = Configuration(parameters, connectors)
         cases = configuration.get_cases()
+
+        Log.print_message("Load exporters")
+        exporters = get_exporters(configuration.connections, connectors)
+        configuration.set_exporter(exporters)
     except Exception as e:
         # Handle any errors that occur during initialization
         Log.print_error(str(e))

--- a/src/ploosh/exporters/__init__.py
+++ b/src/ploosh/exporters/__init__.py
@@ -24,9 +24,9 @@ def get_exporters():
         # Inspect the module to find classes that start with "Exporter"
         for name, obj in inspect.getmembers(module):
             if inspect.isclass(obj) and name.startswith("Exporter"):
-                current_connector = obj()  # Instantiate the exporter class
+                current_exporter = obj()  # Instantiate the exporter class
                 connectors[
-                    current_connector.name
-                ] = current_connector  # Add the exporter to the connectors dictionary
+                    current_exporter.name
+                ] = current_exporter  # Add the exporter to the connectors dictionary
 
     return connectors

--- a/src/ploosh/exporters/__init__.py
+++ b/src/ploosh/exporters/__init__.py
@@ -4,9 +4,9 @@ import os
 import inspect
 
 
-def get_exporters():
+def get_exporters(connections={}, connectors={}):
     """Get all existing exporters"""
-    connectors = {}
+    exporters = {}
 
     # List all Python files in the current directory that start with "exporter_"
     files = [
@@ -25,8 +25,25 @@ def get_exporters():
         for name, obj in inspect.getmembers(module):
             if inspect.isclass(obj) and name.startswith("Exporter"):
                 current_exporter = obj()  # Instantiate the exporter class
-                connectors[
-                    current_exporter.name
-                ] = current_exporter  # Add the exporter to the connectors dictionary
 
-    return connectors
+                if current_exporter.name is None:
+                    continue  # Skip if is the mother class Exporter without a defined name
+
+                # Get the connection for the exporter if defined in the connections file by __export__ name
+                connection = None
+                if "__export__" in connections.keys() and connections["__export__"]["type"].upper() == current_exporter.name.upper():
+                    connection = connections["__export__"]
+
+                # Get the connector for the exporter if defined in the connectors
+                # Will be used to execute the export query
+                connector = None
+                if current_exporter.name.upper() in connectors.keys():
+                    connector = connectors[current_exporter.name.upper()]
+
+                current_exporter.connection = connection
+                current_exporter.connector = connector
+                exporters[
+                    current_exporter.name
+                ] = current_exporter  # Add the exporter to the exporters dictionary
+
+    return exporters

--- a/src/ploosh/exporters/exporter.py
+++ b/src/ploosh/exporters/exporter.py
@@ -1,6 +1,12 @@
 # pylint: disable=R0903,W0613
 """Test result exporter"""
 from datetime import datetime
+import os
+
+import pandas as pd
+from openpyxl.cell.cell import MergedCell
+from openpyxl.styles import Alignment, Border, Font, PatternFill, Side
+from openpyxl.utils import get_column_letter
 
 
 class Exporter:
@@ -19,3 +25,100 @@ class Exporter:
     def export(self, cases: dict, execution_id: str):
         """Export test case results to the destination"""
         return None
+
+
+    def export_gap_file(self, detail_file_path: str, df_compare_gap):
+        """Export comparison gap to a styled Excel file."""
+
+        os.makedirs(os.path.dirname(detail_file_path), exist_ok=True)
+
+        df = df_compare_gap.copy()
+
+        # Remove columns and rows that are entirely empty to avoid clutter in the output file.
+        df = df.dropna(axis=1, how="all").dropna(axis=0, how="all")
+
+        df.index.name = "row"
+
+        with pd.ExcelWriter(detail_file_path, engine="openpyxl") as writer:
+            df.to_excel(writer, sheet_name="gap", merge_cells=True)
+            worksheet = writer.sheets["gap"]
+
+            header_column_fill = PatternFill("solid", fgColor="244062")
+            header_type_fill = PatternFill("solid", fgColor="366092")
+
+            diff_fill = PatternFill("solid", fgColor="F6C9CE")
+            diff_font = Font(color="9C0006")
+            match_fill = PatternFill("solid", fgColor="C6EFCE")
+            match_font = Font(color="006100")
+            header_font = Font(bold=True, color="FFFFFF")
+            index_fill = PatternFill("solid", fgColor="DCE6F1")
+            index_font = Font(bold=True)
+            center = Alignment(horizontal="center", vertical="center")
+            thin = Side(style="thin", color="BFBFBF")
+
+            header_rows = df.columns.nlevels  # 2 levels: column name / expected-source
+            value_columns = len(df.columns)
+
+            # Remove the default header row added by pandas and keep only the multi-level column headers.
+            worksheet.delete_rows(header_rows + 1)
+
+            data_start_row = header_rows + 1
+            data_end_row = data_start_row + len(df) - 1
+            last_column = value_columns + 1  # +1 for the index column
+
+            # Merge the index header cell and style it.
+            worksheet.merge_cells(start_row=1, start_column=1, end_row=header_rows, end_column=1)
+            index_header = worksheet.cell(row=1, column=1, value="row")
+            index_header.fill = header_column_fill
+            index_header.font = header_font
+            index_header.alignment = center
+
+            # Style the column headers.
+            for row in range(1, header_rows + 1):
+                for column in range(2, last_column + 1):
+                    cell = worksheet.cell(row=row, column=column)
+                    if isinstance(cell, MergedCell):
+                        # Non-anchor merged cells are read-only; the anchor carries the style.
+                        continue
+                    cell.fill = header_type_fill if row == header_rows else header_column_fill
+                    cell.font = header_font
+                    cell.alignment = center
+
+            # Style the data area and apply the conditional coloring.
+            group_names = df.columns.get_level_values(0)
+            for offset in range(len(df)):
+                row = data_start_row + offset
+
+                index_cell = worksheet.cell(row=row, column=1)
+                index_cell.fill = index_fill
+                index_cell.font = index_font
+                index_cell.alignment = center
+
+                for group in group_names.unique():
+                    positions = [i for i, name in enumerate(group_names) if name == group]
+                    has_gap = any(not pd.isna(df.iat[offset, position]) for position in positions)
+                    fill = diff_fill if has_gap else match_fill
+                    font = diff_font if has_gap else match_font
+                    for position in positions:
+                        cell = worksheet.cell(row=row, column=position + 2)
+                        cell.fill = fill
+                        cell.font = font
+                        cell.alignment = center
+
+                        cell.border = Border(
+                            left=thin,
+                            right=Side(style="thin", color="000000") if position == positions[-1] else thin,
+                            top=thin,
+                            bottom=thin
+                        )
+
+            # Auto-size columns based on their content.
+            for column in range(1, last_column + 1):
+                letter = get_column_letter(column)
+                lengths = [
+                    len(str(worksheet.cell(row=row, column=column).value))
+                    for row in range(1, data_end_row + 1)
+                    if worksheet.cell(row=row, column=column).value is not None
+                ]
+                worksheet.column_dimensions[letter].width = (max(lengths) if lengths else 5) + 2
+

--- a/src/ploosh/exporters/exporter.py
+++ b/src/ploosh/exporters/exporter.py
@@ -13,6 +13,8 @@ class Exporter:
     """Test result exporter"""
     name = None  # Name of the exporter
     output_path = None  # Output path for the exported results
+    connection = None  # Connection details for the destination (e.g., database connection string, API endpoint)
+    connector = None # Connector instance to interact with the destination (e.g., database connector, API client)
 
     @staticmethod
     def date_to_string(data):
@@ -25,7 +27,6 @@ class Exporter:
     def export(self, cases: dict, execution_id: str):
         """Export test case results to the destination"""
         return None
-
 
     def export_gap_file(self, detail_file_path: str, df_compare_gap):
         """Export comparison gap to a styled Excel file."""

--- a/src/ploosh/exporters/exporter_csv.py
+++ b/src/ploosh/exporters/exporter_csv.py
@@ -49,9 +49,7 @@ class ExporterCSV(Exporter):
             if case.df_compare_gap is not None:
                 detail_file_path = f"{self.output_path}/json/test_results/{name}.xlsx"
 
-                # Create directories if they do not exist
-                os.makedirs(os.path.dirname(detail_file_path), exist_ok=True)
-                case.df_compare_gap.to_excel(detail_file_path)
+                self.export_gap_file(detail_file_path, case.df_compare_gap)
 
             # Collect data for the current test case
             case_data = [

--- a/src/ploosh/exporters/exporter_json.py
+++ b/src/ploosh/exporters/exporter_json.py
@@ -71,9 +71,8 @@ class ExporterJSON(Exporter):
             if case.df_compare_gap is not None:
                 detail_file_path = f"{self.output_path}/json/test_results/{name}.xlsx"
 
-                # Create directories if they do not exist
-                os.makedirs(os.path.dirname(detail_file_path), exist_ok=True)
-                case.df_compare_gap.to_excel(detail_file_path)
+                self.export_gap_file(detail_file_path, case.df_compare_gap)
+
 
                 case_data["error"]["detail_file_path"] = detail_file_path
 

--- a/src/ploosh/exporters/exporter_mysql.py
+++ b/src/ploosh/exporters/exporter_mysql.py
@@ -1,0 +1,74 @@
+from exporters.exporter import Exporter
+
+class ExporterMySQL(Exporter):
+    """Export test case result to MySQL database"""
+
+    CREATE_TABLE_QUERY = """
+        CREATE TABLE IF NOT EXISTS ploosh_results (
+            execution_id VARCHAR(255),
+            name VARCHAR(255),
+            state VARCHAR(50),
+            source_start DATETIME,
+            source_end DATETIME,
+            source_duration FLOAT,
+            source_count BIGINT,
+            source_executed_action VARCHAR(255),
+            expected_start DATETIME,
+            expected_end DATETIME,
+            expected_duration FLOAT,
+            expected_count BIGINT,
+            expected_executed_action VARCHAR(255),
+            compare_start DATETIME,
+            compare_end DATETIME,
+            compare_duration FLOAT,
+            success_rate FLOAT 
+        );
+    """
+    
+    INSERT_QUERY = """
+        INSERT INTO ploosh_results (
+            execution_id, name, state,
+            source_start, source_end, source_duration, source_count, source_executed_action,
+            expected_start, expected_end, expected_duration, expected_count, expected_executed_action,
+            compare_start, compare_end, compare_duration, success_rate
+        ) VALUES (
+            :execution_id, :name, :state,
+            :source_start, :source_end, :source_duration, :source_count, :source_executed_action,
+            :expected_start, :expected_end, :expected_duration, :expected_count, :expected_executed_action,
+            :compare_start, :compare_end, :compare_duration, :success_rate
+        );
+    """
+
+    def __init__(self):
+        # Set the name of the exporter
+        self.name = "MYSQL"
+
+    def export(self, cases: dict, execution_id: str):
+        """Export test case results to a MySQL database"""
+
+        self.connector.execute_query(self.CREATE_TABLE_QUERY, connection=self.connection)
+
+        for case_name, case in cases.items():
+            self.connector.execute_query(
+                self.INSERT_QUERY,
+                connection=self.connection,
+                parameters={
+                    "execution_id": execution_id,
+                    "name": case_name,
+                    "state": case.state,
+                    "source_start": case.source.duration.start,
+                    "source_end": case.source.duration.end,
+                    "source_duration": case.source.duration.duration,
+                    "source_count": case.source.count,
+                    "source_executed_action": case.source.executed_action,
+                    "expected_start": case.expected.duration.start,
+                    "expected_end": case.expected.duration.end,
+                    "expected_duration": case.expected.duration.duration,
+                    "expected_count": case.expected.count,
+                    "expected_executed_action": case.expected.executed_action,
+                    "compare_start": case.compare_duration.start,
+                    "compare_end": case.compare_duration.end,
+                    "compare_duration": case.compare_duration.duration,
+                    "success_rate": case.success_rate,
+                }
+            )

--- a/src/ploosh/exporters/exporter_postgresql.py
+++ b/src/ploosh/exporters/exporter_postgresql.py
@@ -24,7 +24,7 @@ class ExporterPostgreSQL(Exporter):
             success_rate FLOAT 
         );
     """
-    
+
     INSERT_QUERY = """
         INSERT INTO ploosh_results (
             execution_id, name, state,
@@ -45,13 +45,12 @@ class ExporterPostgreSQL(Exporter):
 
     def export(self, cases: dict, execution_id: str):
         """Export test case results to a PostgreSQL database"""
-        
         # Check if connection and connector are available
         if self.connection is None:
-            raise Exception("PostgreSQL export connection not found. Add __export__ section to connections.yml")
+            raise RuntimeError("PostgreSQL export connection not found. Add __export__ section to connections.yml")
         if self.connector is None:
-            raise Exception("PostgreSQL connector not found. Make sure pg8000 is installed.")
-        
+            raise RuntimeError("PostgreSQL connector not found. Make sure pg8000 is installed.")
+
         self.connector.execute_query(self.CREATE_TABLE_QUERY, connection=self.connection)
 
         try:
@@ -79,5 +78,5 @@ class ExporterPostgreSQL(Exporter):
                         "success_rate": case.success_rate,
                     }
                 )
-        except Exception as e:
-            raise Exception(f"Failed to export results to PostgreSQL: {str(e)}")
+        except RuntimeError as e:
+            raise RuntimeError(f"Failed to export results to PostgreSQL: {str(e)}") from e

--- a/src/ploosh/exporters/exporter_postgresql.py
+++ b/src/ploosh/exporters/exporter_postgresql.py
@@ -1,0 +1,83 @@
+from exporters.exporter import Exporter
+
+class ExporterPostgreSQL(Exporter):
+    """Export test case result to PostgreSQL database"""
+
+    CREATE_TABLE_QUERY = """
+        CREATE TABLE IF NOT EXISTS ploosh_results (
+            execution_id VARCHAR(255),
+            name VARCHAR(255),
+            state VARCHAR(50),
+            source_start TIMESTAMP,
+            source_end TIMESTAMP,
+            source_duration FLOAT,
+            source_count BIGINT,
+            source_executed_action VARCHAR(255),
+            expected_start TIMESTAMP,
+            expected_end TIMESTAMP,
+            expected_duration FLOAT,
+            expected_count BIGINT,
+            expected_executed_action VARCHAR(255),
+            compare_start TIMESTAMP,
+            compare_end TIMESTAMP,
+            compare_duration FLOAT,
+            success_rate FLOAT 
+        );
+    """
+    
+    INSERT_QUERY = """
+        INSERT INTO ploosh_results (
+            execution_id, name, state,
+            source_start, source_end, source_duration, source_count, source_executed_action,
+            expected_start, expected_end, expected_duration, expected_count, expected_executed_action,
+            compare_start, compare_end, compare_duration, success_rate
+        ) VALUES (
+            :execution_id, :name, :state,
+            :source_start, :source_end, :source_duration, :source_count, :source_executed_action,
+            :expected_start, :expected_end, :expected_duration, :expected_count, :expected_executed_action,
+            :compare_start, :compare_end, :compare_duration, :success_rate
+        );
+    """
+
+    def __init__(self):
+        # Set the name of the exporter
+        self.name = "POSTGRESQL"
+
+    def export(self, cases: dict, execution_id: str):
+        """Export test case results to a PostgreSQL database"""
+        
+        # Check if connection and connector are available
+        if self.connection is None:
+            raise Exception("PostgreSQL export connection not found. Add __export__ section to connections.yml")
+        if self.connector is None:
+            raise Exception("PostgreSQL connector not found. Make sure pg8000 is installed.")
+        
+        self.connector.execute_query(self.CREATE_TABLE_QUERY, connection=self.connection)
+
+        try:
+            for case_name, case in cases.items():
+                self.connector.execute_query(
+                    self.INSERT_QUERY,
+                    connection=self.connection,
+                    parameters={
+                        "execution_id": execution_id,
+                        "name": case_name,
+                        "state": case.state,
+                        "source_start": case.source.duration.start,
+                        "source_end": case.source.duration.end,
+                        "source_duration": case.source.duration.duration,
+                        "source_count": case.source.count,
+                        "source_executed_action": case.source.executed_action,
+                        "expected_start": case.expected.duration.start,
+                        "expected_end": case.expected.duration.end,
+                        "expected_duration": case.expected.duration.duration,
+                        "expected_count": case.expected.count,
+                        "expected_executed_action": case.expected.executed_action,
+                        "compare_start": case.compare_duration.start,
+                        "compare_end": case.compare_duration.end,
+                        "compare_duration": case.compare_duration.duration,
+                        "success_rate": case.success_rate,
+                    }
+                )
+        except Exception as e:
+            raise Exception(f"Failed to export results to PostgreSQL: {str(e)}")

--- a/src/ploosh/exporters/exporter_trx.py
+++ b/src/ploosh/exporters/exporter_trx.py
@@ -30,9 +30,7 @@ class ExporterTRX(Exporter):
             detail_file_path = f"{output_folder}/test_results/In/{execution_id}/{case_name}.xlsx"
             result_files_xml = f"<ResultFiles><ResultFile path='{case_name}.xlsx'/></ResultFiles>"
 
-            # Create directories if they do not exist
-            os.makedirs(os.path.dirname(detail_file_path), exist_ok=True)
-            current_case.df_compare_gap.to_excel(detail_file_path)
+            self.export_gap_file(detail_file_path, current_case.df_compare_gap)
 
         return output_message_xml, result_files_xml
 

--- a/src/ploosh/version.py
+++ b/src/ploosh/version.py
@@ -1,3 +1,3 @@
 """Current version of ploosh"""
 
-PLOOSH_VERSION = "0.5.6"
+PLOOSH_VERSION = "0.6.0"

--- a/tests/exporters/test_mysql.py
+++ b/tests/exporters/test_mysql.py
@@ -1,0 +1,184 @@
+import pytest
+from datetime import datetime
+from ploosh.exporters.exporter_mysql import ExporterMySQL
+
+
+class MockDuration:
+    def __init__(self, start, end, duration):
+        self.start = start
+        self.end = end
+        self.duration = duration
+
+
+class MockSource:
+    def __init__(self, executed_action=None, count=10):
+        self.duration = MockDuration(datetime(2024, 10, 7, 11, 55, 0), datetime(2024, 10, 7, 11, 55, 5), 5)
+        self.count = count
+        self.executed_action = executed_action
+
+
+class MockCase:
+    def __init__(self, state, source_executed_action=None, expected_executed_action=None, success_rate=0.95):
+        self.state = state
+        self.source = MockSource(source_executed_action)
+        self.expected = MockSource(expected_executed_action)
+        self.compare_duration = MockDuration(datetime(2024, 10, 7, 11, 55, 13), datetime(2024, 10, 7, 11, 55, 15), 2)
+        self.success_rate = success_rate
+
+
+class MockConnector:
+    """Capture every execute_query call without touching a real database."""
+
+    def __init__(self):
+        self.calls = []  # list of dicts: {"query", "connection", "parameters"}
+
+    def execute_query(self, query, connection, parameters=None):
+        self.calls.append({
+            "query": query,
+            "connection": connection,
+            "parameters": parameters,
+        })
+        return None
+
+
+@pytest.fixture
+def connection():
+    return {"type": "mysql", "hostname": "localhost", "database": "test_db"}
+
+
+@pytest.fixture
+def exporter(connection):
+    exporter = ExporterMySQL()
+    exporter.connector = MockConnector()
+    exporter.connection = connection
+    return exporter
+
+
+def test_create_table_called_once(exporter):
+    cases = {
+        "test_case_1": MockCase("passed", "SELECT * FROM table1", "SELECT * FROM table2"),
+    }
+
+    exporter.export(cases, "test_execution_123")
+
+    # First call must be the CREATE TABLE statement, without parameters
+    first_call = exporter.connector.calls[0]
+    assert first_call["query"] == ExporterMySQL.CREATE_TABLE_QUERY
+    assert first_call["parameters"] is None
+
+
+def test_insert_per_case(exporter):
+    cases = {
+        "test_case_1": MockCase("passed"),
+        "test_case_2": MockCase("failed"),
+        "test_case_3": MockCase("error"),
+    }
+
+    exporter.export(cases, "test_execution_123")
+
+    # 1 CREATE TABLE + 1 INSERT per case
+    assert len(exporter.connector.calls) == 1 + len(cases)
+
+    insert_calls = exporter.connector.calls[1:]
+    assert all(call["query"] == ExporterMySQL.INSERT_QUERY for call in insert_calls)
+
+
+def test_insert_parameters_mapping(exporter):
+    cases = {
+        "test_case_1": MockCase("passed", "SELECT * FROM table1", "SELECT * FROM table2"),
+    }
+
+    exporter.export(cases, "test_execution_123")
+
+    params = exporter.connector.calls[1]["parameters"]
+
+    assert params["execution_id"] == "test_execution_123"
+    assert params["name"] == "test_case_1"
+    assert params["state"] == "passed"
+    assert params["source_duration"] == 5
+    assert params["source_count"] == 10
+    assert params["source_executed_action"] == "SELECT * FROM table1"
+    assert params["expected_duration"] == 5
+    assert params["expected_count"] == 10
+    assert params["expected_executed_action"] == "SELECT * FROM table2"
+    assert params["compare_duration"] == 2
+    assert params["success_rate"] == 0.95
+
+
+def test_execution_id_propagated(exporter):
+    cases = {
+        "test_case_1": MockCase("passed"),
+        "test_case_2": MockCase("failed"),
+    }
+
+    exporter.export(cases, "shared_execution_id")
+
+    insert_calls = exporter.connector.calls[1:]
+    assert all(call["parameters"]["execution_id"] == "shared_execution_id" for call in insert_calls)
+
+
+def test_datetime_passed_raw(exporter):
+    cases = {
+        "test_case_1": MockCase("passed"),
+    }
+
+    exporter.export(cases, "test_execution_123")
+
+    params = exporter.connector.calls[1]["parameters"]
+
+    # MySQL exporter forwards raw datetime objects (no ISO string conversion)
+    assert isinstance(params["source_start"], datetime)
+    assert isinstance(params["source_end"], datetime)
+    assert isinstance(params["expected_start"], datetime)
+    assert isinstance(params["expected_end"], datetime)
+    assert isinstance(params["compare_start"], datetime)
+    assert isinstance(params["compare_end"], datetime)
+    assert params["source_start"] == datetime(2024, 10, 7, 11, 55, 0)
+    assert params["compare_end"] == datetime(2024, 10, 7, 11, 55, 15)
+
+
+def test_connection_forwarded(exporter, connection):
+    cases = {
+        "test_case_1": MockCase("passed"),
+    }
+
+    exporter.export(cases, "test_execution_123")
+
+    assert all(call["connection"] == connection for call in exporter.connector.calls)
+
+
+def test_multiple_states(exporter):
+    cases = {
+        "passed_case": MockCase("passed"),
+        "failed_case": MockCase("failed"),
+        "error_case": MockCase("error"),
+    }
+
+    exporter.export(cases, "test_execution_123")
+
+    states = [call["parameters"]["state"] for call in exporter.connector.calls[1:]]
+    names = [call["parameters"]["name"] for call in exporter.connector.calls[1:]]
+
+    assert states == ["passed", "failed", "error"]
+    assert names == ["passed_case", "failed_case", "error_case"]
+
+
+def test_empty_cases(exporter):
+    exporter.export({}, "test_execution_123")
+
+    # Only the CREATE TABLE statement should be executed, no INSERT
+    assert len(exporter.connector.calls) == 1
+    assert exporter.connector.calls[0]["query"] == ExporterMySQL.CREATE_TABLE_QUERY
+
+
+def test_query_uses_named_params(exporter):
+    cases = {
+        "test_case_1": MockCase("passed"),
+    }
+
+    exporter.export(cases, "test_execution_123")
+
+    insert_query = exporter.connector.calls[1]["query"]
+
+    for placeholder in [":execution_id", ":name", ":state", ":source_start", ":success_rate"]:
+        assert placeholder in insert_query

--- a/tests/exporters/test_postgresql.py
+++ b/tests/exporters/test_postgresql.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from ploosh.exporters.exporter_postgresql import ExporterPostgreSQL
 
 
+
 class MockDuration:
     def __init__(self, start, end, duration):
         self.start = start

--- a/tests/exporters/test_postgresql.py
+++ b/tests/exporters/test_postgresql.py
@@ -1,0 +1,206 @@
+import pytest
+from datetime import datetime
+from ploosh.exporters.exporter_postgresql import ExporterPostgreSQL
+
+
+class MockDuration:
+    def __init__(self, start, end, duration):
+        self.start = start
+        self.end = end
+        self.duration = duration
+
+
+class MockSource:
+    def __init__(self, executed_action=None, count=10):
+        self.duration = MockDuration(datetime(2024, 10, 7, 11, 55, 0), datetime(2024, 10, 7, 11, 55, 5), 5)
+        self.count = count
+        self.executed_action = executed_action
+
+
+class MockCase:
+    def __init__(self, state, source_executed_action=None, expected_executed_action=None, success_rate=0.95):
+        self.state = state
+        self.source = MockSource(source_executed_action)
+        self.expected = MockSource(expected_executed_action)
+        self.compare_duration = MockDuration(datetime(2024, 10, 7, 11, 55, 13), datetime(2024, 10, 7, 11, 55, 15), 2)
+        self.success_rate = success_rate
+
+
+class MockConnector:
+    """Capture every execute_query call without touching a real database."""
+
+    def __init__(self):
+        self.calls = []  # list of dicts: {"query", "connection", "parameters"}
+
+    def execute_query(self, query, connection, parameters=None):
+        self.calls.append({
+            "query": query,
+            "connection": connection,
+            "parameters": parameters,
+        })
+        return None
+
+
+@pytest.fixture
+def connection():
+    return {"type": "postgresql", "hostname": "localhost", "database": "test_db", "port": 5432}
+
+
+@pytest.fixture
+def exporter(connection):
+    exporter = ExporterPostgreSQL()
+    exporter.connector = MockConnector()
+    exporter.connection = connection
+    return exporter
+
+
+def test_create_table_called_once(exporter):
+    cases = {
+        "test_case_1": MockCase("passed", "SELECT * FROM table1", "SELECT * FROM table2"),
+    }
+
+    exporter.export(cases, "test_execution_123")
+
+    # First call must be the CREATE TABLE statement, without parameters
+    first_call = exporter.connector.calls[0]
+    assert first_call["query"] == ExporterPostgreSQL.CREATE_TABLE_QUERY
+    assert first_call["parameters"] is None
+
+
+def test_insert_per_case(exporter):
+    cases = {
+        "test_case_1": MockCase("passed"),
+        "test_case_2": MockCase("failed"),
+        "test_case_3": MockCase("error"),
+    }
+
+    exporter.export(cases, "test_execution_123")
+
+    # 1 CREATE TABLE + 1 INSERT per case
+    assert len(exporter.connector.calls) == 1 + len(cases)
+
+    insert_calls = exporter.connector.calls[1:]
+    assert all(call["query"] == ExporterPostgreSQL.INSERT_QUERY for call in insert_calls)
+
+
+def test_insert_parameters_mapping(exporter):
+    cases = {
+        "test_case_1": MockCase("passed", "SELECT * FROM table1", "SELECT * FROM table2"),
+    }
+
+    exporter.export(cases, "test_execution_123")
+
+    params = exporter.connector.calls[1]["parameters"]
+
+    assert params["execution_id"] == "test_execution_123"
+    assert params["name"] == "test_case_1"
+    assert params["state"] == "passed"
+    assert params["source_duration"] == 5
+    assert params["source_count"] == 10
+    assert params["source_executed_action"] == "SELECT * FROM table1"
+    assert params["expected_duration"] == 5
+    assert params["expected_count"] == 10
+    assert params["expected_executed_action"] == "SELECT * FROM table2"
+    assert params["compare_duration"] == 2
+    assert params["success_rate"] == 0.95
+
+
+def test_execution_id_propagated(exporter):
+    cases = {
+        "test_case_1": MockCase("passed"),
+        "test_case_2": MockCase("failed"),
+    }
+
+    exporter.export(cases, "shared_execution_id")
+
+    insert_calls = exporter.connector.calls[1:]
+    assert all(call["parameters"]["execution_id"] == "shared_execution_id" for call in insert_calls)
+
+
+def test_datetime_passed_raw(exporter):
+    cases = {
+        "test_case_1": MockCase("passed"),
+    }
+
+    exporter.export(cases, "test_execution_123")
+
+    params = exporter.connector.calls[1]["parameters"]
+
+    # PostgreSQL exporter forwards raw datetime objects (no ISO string conversion)
+    assert isinstance(params["source_start"], datetime)
+    assert isinstance(params["source_end"], datetime)
+    assert isinstance(params["expected_start"], datetime)
+    assert isinstance(params["expected_end"], datetime)
+    assert isinstance(params["compare_start"], datetime)
+    assert isinstance(params["compare_end"], datetime)
+    assert params["source_start"] == datetime(2024, 10, 7, 11, 55, 0)
+    assert params["compare_end"] == datetime(2024, 10, 7, 11, 55, 15)
+
+
+def test_connection_forwarded(exporter, connection):
+    cases = {
+        "test_case_1": MockCase("passed"),
+    }
+
+    exporter.export(cases, "test_execution_123")
+
+    assert all(call["connection"] == connection for call in exporter.connector.calls)
+
+
+def test_multiple_states(exporter):
+    cases = {
+        "passed_case": MockCase("passed"),
+        "failed_case": MockCase("failed"),
+        "error_case": MockCase("error"),
+    }
+
+    exporter.export(cases, "test_execution_123")
+
+    states = [call["parameters"]["state"] for call in exporter.connector.calls[1:]]
+    names = [call["parameters"]["name"] for call in exporter.connector.calls[1:]]
+
+    assert states == ["passed", "failed", "error"]
+    assert names == ["passed_case", "failed_case", "error_case"]
+
+
+def test_empty_cases(exporter):
+    exporter.export({}, "test_execution_123")
+
+    # Only the CREATE TABLE statement should be executed, no INSERT
+    assert len(exporter.connector.calls) == 1
+    assert exporter.connector.calls[0]["query"] == ExporterPostgreSQL.CREATE_TABLE_QUERY
+
+
+def test_query_uses_named_params(exporter):
+    cases = {
+        "test_case_1": MockCase("passed"),
+    }
+
+    exporter.export(cases, "test_execution_123")
+
+    insert_query = exporter.connector.calls[1]["query"]
+
+    for placeholder in [":execution_id", ":name", ":state", ":source_start", ":success_rate"]:
+        assert placeholder in insert_query
+
+
+def test_connection_missing_raises_error():
+    exporter = ExporterPostgreSQL()
+    exporter.connector = MockConnector()
+    exporter.connection = None
+
+    cases = {"test_case_1": MockCase("passed")}
+
+    with pytest.raises(Exception, match="PostgreSQL export connection not found"):
+        exporter.export(cases, "test_execution_123")
+
+
+def test_connector_missing_raises_error():
+    exporter = ExporterPostgreSQL()
+    exporter.connector = None
+    exporter.connection = {"type": "postgresql", "hostname": "localhost"}
+
+    cases = {"test_case_1": MockCase("passed")}
+
+    with pytest.raises(Exception, match="PostgreSQL connector not found"):
+        exporter.export(cases, "test_execution_123")


### PR DESCRIPTION
## Description

This PR merges `develop` into `main` for the **0.6.0** release. It reworks the exporter system around connections/connectors, introduces two new database exporters (MySQL and PostgreSQL), fixes empty KQL dataset handling in API mode, and improves Spark comparison with multi-index gap handling.

## Type of change

- [x] feat — new feature
- [x] fix — bug fix
- [x] docs — documentation only
- [ ] style — formatting, no code change
- [x] refactor — code change that neither fixes a bug nor adds a feature
- [ ] perf — performance improvement
- [x] test — adding or updating tests
- [x] chore — build, tooling, or maintenance

## Scope

`exporter`, `connector`, `compare-engine`, `docs`, tooling

## Changes

- **Exporters**
  - Add base `Exporter` class to use connections and connectors (`src/ploosh/exporters/exporter.py`).
  - Add new **MySQL exporter** to save test case results in a MySQL database (`exporter_mysql.py`).
  - Add new **PostgreSQL exporter** (`exporter_postgresql.py`).
  - Refactor `exporter_csv.py`, `exporter_json.py`, `exporter_trx.py` and `exporters/__init__.py` to the new connection-based pattern.
  - Add `export` parameter to the `execute_cases` API.
  - Add Excel export styling.
- **Connectors / Compare engine**
  - Fix empty KQL dataset response handling in `ConnectorFabricKqlSpark` (API mode).
  - Enhance comparison gap handling with multi-index columns (pandas-like export) in `compare_engine_spark.py`.
  - Rename variables to English for clarity in `compare_data`.
- **Tooling / Docs / Release**
  - Add pull request template to standardize contributions.
  - Add docs for MySQL and PostgreSQL exporters.
  - Bump version **0.5.6 → 0.6.0** (`pyproject.toml`, `src/ploosh/version.py`).
 `tests/compare_engine` / `tests/load_engine`

## Documentation

- [x] Updated relevant docs under `docs/` (new exporter pages for MySQL and PostgreSQL)
- [ ] No documentation change needed

## Included PRs

- #142 — Add PostgreSQL exporter
- #139 — Exports enhancement (MySQL exporter, connection-based exporters, Excel styling)
- #138 — Fix empty KQL dataset with API